### PR TITLE
Allow overriding kwargs with field_kwargs

### DIFF
--- a/src/argparse_pydantic/core.py
+++ b/src/argparse_pydantic/core.py
@@ -120,8 +120,8 @@ def add_field_arg(
     if field_info.json_schema_extra:
         field_kwargs = parse_field_kwargs(field_info.json_schema_extra)
         kwargs = {
-            **field_kwargs,
             **kwargs,
+            **field_kwargs,
         }
 
     if "flag" in kwargs:


### PR DESCRIPTION
Moving this line should allow `field_kwargs` to override `kwargs`. The use case is that I want to use `type=datetime.fromisoformat` for my datetime fields. This change will allow this pattern in the pydantic model:

```
    my_date: datetime = Field(
        json_schema_extra=argument_kwargs(
            type=datetime.fromisoformat,
        ),
        ...
    )
```